### PR TITLE
Simplify binding

### DIFF
--- a/example/example.rb
+++ b/example/example.rb
@@ -2,23 +2,23 @@
 
 include Cute
 
-puts "Hello, you are running #{version_string_linked}!"
+puts "Hello, you are running #{cf_version_string_linked}!"
 
-result = make_app("Example App", 0, 0, 0, 800, 600, APP_OPTIONS_WINDOW_POS_CENTERED_BIT, "example.rb")
+result = cf_make_app("Example App", 0, 0, 0, 800, 600, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, "example.rb")
 
-if result.error?
+if cf_is_error(result)
   puts "Error creating app: #{result.details}"
   exit(1)
 end
 
-sprite = Sprite.make_demo_sprite
+sprite = Sprite.new(cf_make_demo_sprite)
 sprite.play("spin")
 
-while app_is_running
-  app_update
+while cf_app_is_running
+  cf_app_update
   sprite.update
   sprite.draw
-  app_draw_onto_screen
+  cf_app_draw_onto_screen
 end
 
-app_destroy
+cf_app_destroy

--- a/include/mruby-cute.h
+++ b/include/mruby-cute.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <cute.h>
 #include <mruby.h>
+#include <mruby/data.h>
 
-#define DEFINE_MODULE_FUNCTION(name, args) mrb_define_module_function(mrb, mrb_cute_module, #name, mrbcf_##name, args)
-#define DEFINE_MODULE_CONSTANT(name) mrb_define_const(mrb, mrb_cute_module, #name, mrb_fixnum_value(CF_##name))
+static const struct mrb_data_type mrb_cf_result_type = {"CF_Result", mrb_free};
 
 void mrb_cute_app_init(mrb_state* mrb, struct RClass* mrb_cute_module);
 void mrb_cute_result_init(mrb_state* mrb, struct RClass* mrb_cute_module);

--- a/mrblib/sprite.rb
+++ b/mrblib/sprite.rb
@@ -1,0 +1,14 @@
+module Cute
+  class Sprite
+    def initialize(cf_sprite)
+      @cf_sprite = cf_sprite || Cute.cf_sprite_defaults
+    end
+
+    def width = Cute.cf_sprite_width(@cf_sprite)
+    def height = Cute.cf_sprite_height(@cf_sprite)
+    def playing?(name) = Cute.cf_sprite_is_playing(@cf_sprite, name)
+    def play(name) = Cute.cf_sprite_play(@cf_sprite, name)
+    def update = Cute.cf_sprite_update(@cf_sprite)
+    def draw = Cute.cf_sprite_draw(@cf_sprite)
+  end
+end

--- a/src/app.c
+++ b/src/app.c
@@ -6,7 +6,7 @@
 #include <mruby/string.h>
 #include <mruby/variable.h>
 
-static mrb_value mrbcf_make_app(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_make_app(mrb_state* mrb, mrb_value self)
 {
   char* window_title = NULL;
   mrb_int display_id;
@@ -19,35 +19,36 @@ static mrb_value mrbcf_make_app(mrb_state* mrb, mrb_value self)
 
   mrb_get_args(mrb, "ziiiiiiz", &window_title, &display_id, &x, &y, &w, &h, &options, &argv0);
 
-  CF_Result result = cf_make_app(window_title, display_id, x, y, w, h, options, argv0);
-
-  return mrb_cf_result_from_cf_result(mrb, result); // TODO: Should this be mrb_cute_result_from_cf_result?
+  CF_Result* result_ptr = (CF_Result*) mrb_malloc(mrb, sizeof(CF_Result));
+  *result_ptr = cf_make_app(window_title, display_id, x, y, w, h, options, argv0);
+  struct RClass* cf_result_class = mrb_class_get_under(mrb, mrb_module_get(mrb, "Cute"), "CF_Result");
+  return mrb_obj_value(Data_Wrap_Struct(mrb, cf_result_class, &mrb_cf_result_type, result_ptr));
 }
 
-static mrb_value mrbcf_app_is_running(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_app_is_running(mrb_state* mrb, mrb_value self)
 {
   return mrb_bool_value(cf_app_is_running());
 }
 
-static mrb_value mrbcf_app_destroy(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_app_destroy(mrb_state* mrb, mrb_value self)
 {
   cf_destroy_app();
   return mrb_nil_value();
 }
 
-static mrb_value mrbcf_app_update(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_app_update(mrb_state* mrb, mrb_value self)
 {
   // TODO: Add support for the OnUpdate callback.
   cf_app_update(NULL);
   return mrb_nil_value();
 }
 
-static mrb_value mrbcf_default_display(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_default_display(mrb_state* mrb, mrb_value self)
 {
   return mrb_fixnum_value(cf_default_display());
 }
 
-static mrb_value mrbcf_app_draw_onto_screen(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_app_draw_onto_screen(mrb_state* mrb, mrb_value self)
 {
   mrb_bool clear_to_black = true;
   mrb_get_args(mrb, "|b", &clear_to_black);
@@ -58,26 +59,28 @@ static mrb_value mrbcf_app_draw_onto_screen(mrb_state* mrb, mrb_value self)
 
 static void define_constants(mrb_state* mrb, struct RClass* mrb_cute_module)
 {
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_NO_GFX_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_FULLSCREEN_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_RESIZABLE_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_HIDDEN_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_WINDOW_POS_CENTERED_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_FILE_SYSTEM_DONT_DEFAULT_MOUNT_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_NO_AUDIO_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_GFX_D3D11_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_GFX_D3D12_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_GFX_METAL_BIT);
-  DEFINE_MODULE_CONSTANT(APP_OPTIONS_GFX_VULKAN_BIT);
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_NO_GFX_BIT", mrb_fixnum_value(CF_APP_OPTIONS_NO_GFX_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_FULLSCREEN_BIT", mrb_fixnum_value(CF_APP_OPTIONS_FULLSCREEN_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_RESIZABLE_BIT", mrb_fixnum_value(CF_APP_OPTIONS_RESIZABLE_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_HIDDEN_BIT", mrb_fixnum_value(CF_APP_OPTIONS_HIDDEN_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT",
+                   mrb_fixnum_value(CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_FILE_SYSTEM_DONT_DEFAULT_MOUNT_BIT",
+                   mrb_fixnum_value(CF_APP_OPTIONS_FILE_SYSTEM_DONT_DEFAULT_MOUNT_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_NO_AUDIO_BIT", mrb_fixnum_value(CF_APP_OPTIONS_NO_AUDIO_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_GFX_D3D11_BIT", mrb_fixnum_value(CF_APP_OPTIONS_GFX_D3D11_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_GFX_D3D12_BIT", mrb_fixnum_value(CF_APP_OPTIONS_GFX_D3D12_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_GFX_METAL_BIT", mrb_fixnum_value(CF_APP_OPTIONS_GFX_METAL_BIT));
+  mrb_define_const(mrb, mrb_cute_module, "CF_APP_OPTIONS_GFX_VULKAN_BIT", mrb_fixnum_value(CF_APP_OPTIONS_GFX_VULKAN_BIT));
 }
 
 void mrb_cute_app_init(mrb_state* mrb, struct RClass* mrb_cute_module)
 {
-  DEFINE_MODULE_FUNCTION(make_app, MRB_ARGS_REQ(7));
-  DEFINE_MODULE_FUNCTION(app_is_running, MRB_ARGS_NONE());
-  DEFINE_MODULE_FUNCTION(app_destroy, MRB_ARGS_NONE());
-  DEFINE_MODULE_FUNCTION(app_update, MRB_ARGS_NONE());
-  DEFINE_MODULE_FUNCTION(default_display, MRB_ARGS_NONE());
-  DEFINE_MODULE_FUNCTION(app_draw_onto_screen, MRB_ARGS_OPT(1));
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_make_app", mrb_cf_make_app, MRB_ARGS_REQ(7));
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_app_is_running", mrb_cf_app_is_running, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_app_destroy", mrb_cf_app_destroy, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_app_update", mrb_cf_app_update, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_default_display", mrb_cf_default_display, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_app_draw_onto_screen", mrb_cf_app_draw_onto_screen, MRB_ARGS_OPT(1));
   define_constants(mrb, mrb_cute_module);
 }

--- a/src/cute.c
+++ b/src/cute.c
@@ -4,14 +4,14 @@
 
 struct RClass* mrb_cute_module;
 
-static mrb_value mrbcf_version_string_linked(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_version_string_linked(mrb_state* mrb, mrb_value self)
 {
   return mrb_str_new_cstr(mrb, cf_version_string_linked());
 }
 
 static void mrb_cute_init(mrb_state* mrb, struct RClass* mrb_cute_module)
 {
-  DEFINE_MODULE_FUNCTION(version_string_linked, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, mrb_cute_module, "cf_version_string_linked", mrb_cf_version_string_linked, MRB_ARGS_NONE());
 }
 
 void mrb_mruby_cute_gem_init(mrb_state* mrb)

--- a/src/result.c
+++ b/src/result.c
@@ -1,55 +1,17 @@
 #include "cute.h"
+#include "mruby-cute.h"
 #include <mruby.h>
 #include <mruby/class.h>
 #include <mruby/data.h>
 #include <mruby/string.h>
 
-static void mrb_cf_result_free(mrb_state* mrb, void* p)
-{
-  if (p) {
-    mrb_free(mrb, p);
-  }
-}
-
-static const struct mrb_data_type mrb_cf_result_type = {"CF_Result", mrb_cf_result_free};
-
 static mrb_value mrb_cf_result_initialize(mrb_state* mrb, mrb_value self)
 {
-  CF_Result* result = (CF_Result*) DATA_PTR(self);
-  if (result) {
-    mrb_cf_result_free(mrb, result);
-  }
+  CF_Sprite* sprite = (CF_Sprite*) DATA_PTR(self);
+  if (sprite) mrb_free(mrb, sprite);
   DATA_TYPE(self) = &mrb_cf_result_type;
-  DATA_PTR(self) = NULL;
-
-  mrb_int code;
-  char* details = NULL;
-  mrb_get_args(mrb, "i|z!", &code, &details);
-
-  result = (CF_Result*) mrb_malloc(mrb, sizeof(CF_Result));
-  result->code = code;
-  result->details = details ? details : NULL;
-  DATA_PTR(self) = result;
-
+  DATA_PTR(self) = mrb_malloc(mrb, sizeof(CF_Sprite));
   return self;
-}
-
-static mrb_value mrb_cf_result_code(mrb_state* mrb, mrb_value self)
-{
-  CF_Result* result = DATA_PTR(self);
-  return mrb_fixnum_value(result->code);
-}
-
-static mrb_value mrb_cf_result_details(mrb_state* mrb, mrb_value self)
-{
-  CF_Result* result = DATA_PTR(self);
-  return result->details ? mrb_str_new_cstr(mrb, result->details) : mrb_nil_value();
-}
-
-static mrb_value mrb_cf_result_is_error(mrb_state* mrb, mrb_value self)
-{
-  CF_Result* result = DATA_PTR(self);
-  return mrb_bool_value(result->code == CF_RESULT_ERROR);
 }
 
 static mrb_value mrb_cf_is_error(mrb_state* mrb, mrb_value self)
@@ -61,27 +23,14 @@ static mrb_value mrb_cf_is_error(mrb_state* mrb, mrb_value self)
   return mrb_bool_value(cf_is_error(result));
 }
 
-mrb_value mrb_cf_result_from_cf_result(mrb_state* mrb, CF_Result result)
-{
-  struct RClass* cute_module = mrb_module_get(mrb, "Cute");
-  struct RClass* result_class = mrb_class_get_under(mrb, cute_module, "Result");
-
-  mrb_value args[2];
-  args[0] = mrb_fixnum_value(result.code);
-  args[1] = result.details ? mrb_str_new_cstr(mrb, result.details) : mrb_nil_value();
-
-  return mrb_obj_new(mrb, result_class, 2, args);
-}
-
 void mrb_cute_result_init(mrb_state* mrb, struct RClass* cute_module)
 {
-  struct RClass* result_class = mrb_define_class_under(mrb, cute_module, "Result", mrb->object_class);
-  MRB_SET_INSTANCE_TT(result_class, MRB_TT_DATA);
+  // CF_Result
+  struct RClass* cf_result_class = mrb_define_class_under(mrb, cute_module, "CF_Result", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cf_result_class, MRB_TT_DATA);
 
-  mrb_define_method(mrb, result_class, "initialize", mrb_cf_result_initialize, MRB_ARGS_ARG(1, 1));
-  mrb_define_method(mrb, result_class, "code", mrb_cf_result_code, MRB_ARGS_NONE());
-  mrb_define_method(mrb, result_class, "details", mrb_cf_result_details, MRB_ARGS_NONE());
-  mrb_define_method(mrb, result_class, "error?", mrb_cf_result_is_error, MRB_ARGS_NONE());
+  mrb_define_method(mrb, cf_result_class, "initialize", mrb_cf_result_initialize, MRB_ARGS_NONE());
 
-  mrb_define_module_function(mrb, cute_module, "is_error", mrb_cf_is_error, MRB_ARGS_REQ(1));
+  // cute_result
+  mrb_define_module_function(mrb, cute_module, "cf_is_error", mrb_cf_is_error, MRB_ARGS_REQ(1));
 }

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -2,100 +2,96 @@
 #include <cute.h>
 #include <mruby.h>
 #include <mruby/class.h>
-#include <mruby/data.h>
-#include <mruby/string.h>
 
-static void mrb_sprite_free(mrb_state* mrb, void* p)
+static const struct mrb_data_type mrb_cf_sprite_type = {"CF_Sprite", mrb_free};
+
+static mrb_value mrb_cf_sprite_defaults(mrb_state* mrb, mrb_value self)
 {
-  if (p) {
-    mrb_free(mrb, p);
-  }
+  CF_Sprite* sprite_ptr = (CF_Sprite*) mrb_malloc(mrb, sizeof(CF_Sprite));
+  *sprite_ptr = cf_sprite_defaults();
+  struct RClass* cf_sprite_class = mrb_class_get_under(mrb, mrb_module_get(mrb, "Cute"), "CF_Sprite");
+  return mrb_obj_value(Data_Wrap_Struct(mrb, cf_sprite_class, &mrb_cf_sprite_type, sprite_ptr));
 }
 
-static const struct mrb_data_type mrb_sprite_type = {"Sprite", mrb_sprite_free};
-
-static mrb_value mrb_sprite_make_sprite(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_make_demo_sprite(mrb_state* mrb, mrb_value self)
 {
-  char* aseprite_path;
-  mrb_get_args(mrb, "z", &aseprite_path);
-
-  CF_Sprite* sprite = (CF_Sprite*) mrb_malloc(mrb, sizeof(CF_Sprite));
-  *sprite = cf_make_sprite(aseprite_path);
-
-  struct RClass* cute_module = mrb_module_get(mrb, "Cute");
-  struct RData* data = mrb_data_object_alloc(mrb, mrb_class_get_under(mrb, cute_module, "Sprite"), sprite, &mrb_sprite_type);
-  return mrb_obj_value(data);
+  CF_Sprite* sprite_ptr = (CF_Sprite*) mrb_malloc(mrb, sizeof(CF_Sprite));
+  *sprite_ptr = cf_make_demo_sprite();
+  struct RClass* cf_sprite_class = mrb_class_get_under(mrb, mrb_module_get(mrb, "Cute"), "CF_Sprite");
+  return mrb_obj_value(Data_Wrap_Struct(mrb, cf_sprite_class, &mrb_cf_sprite_type, sprite_ptr));
 }
 
-static mrb_value mrb_sprite_make_demo_sprite(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_sprite_draw(mrb_state* mrb, mrb_value self)
 {
-  CF_Sprite* sprite = (CF_Sprite*) mrb_malloc(mrb, sizeof(CF_Sprite));
-  *sprite = cf_make_demo_sprite();
-
-  struct RClass* cute_module = mrb_module_get(mrb, "Cute");
-  struct RData* data = mrb_data_object_alloc(mrb, mrb_class_get_under(mrb, cute_module, "Sprite"), sprite, &mrb_sprite_type);
-  return mrb_obj_value(data);
-}
-
-static mrb_value mrb_sprite_draw(mrb_state* mrb, mrb_value self)
-{
-  CF_Sprite* sprite = DATA_PTR(self);
-  if (!sprite) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "Sprite is not initialized");
-  }
-
-  cf_draw_sprite(sprite);
+  CF_Sprite* sprite;
+  mrb_get_args(mrb, "d", &sprite, &mrb_cf_sprite_type);
+  cf_sprite_draw(sprite);
   return mrb_nil_value();
 }
 
-static mrb_value mrb_sprite_play(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_sprite_update(mrb_state* mrb, mrb_value self)
 {
-  CF_Sprite* sprite = DATA_PTR(self);
-  if (!sprite) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "Sprite is not initialized");
-  }
-
-  char* animation_name;
-  mrb_get_args(mrb, "z", &animation_name);
-
-  cf_sprite_play(sprite, animation_name);
-  return self;
-}
-
-static mrb_value mrb_sprite_update(mrb_state* mrb, mrb_value self)
-{
-  CF_Sprite* sprite = DATA_PTR(self);
-  if (!sprite) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "Sprite is not initialized");
-  }
-
+  CF_Sprite* sprite;
+  mrb_get_args(mrb, "d", &sprite, &mrb_cf_sprite_type);
   cf_sprite_update(sprite);
-  return self;
+  return mrb_nil_value();
 }
 
-static mrb_value mrb_sprite_is_playing(mrb_state* mrb, mrb_value self)
+static mrb_value mrb_cf_sprite_play(mrb_state* mrb, mrb_value self)
 {
-  CF_Sprite* sprite = DATA_PTR(self);
-  if (!sprite) {
-    mrb_raise(mrb, E_RUNTIME_ERROR, "Sprite is not initialized");
-  }
+  CF_Sprite* sprite;
+  char* animation;
+  mrb_get_args(mrb, "dz", &sprite, &mrb_cf_sprite_type, &animation);
+  cf_sprite_play(sprite, animation);
+  return mrb_nil_value();
+}
 
-  char* animation_name;
-  mrb_get_args(mrb, "z", &animation_name);
+static mrb_value mrb_cf_sprite_is_playing(mrb_state* mrb, mrb_value self)
+{
+  CF_Sprite* sprite;
+  char* animation;
+  mrb_get_args(mrb, "dz", &sprite, &mrb_cf_sprite_type, &animation);
+  return mrb_bool_value(cf_sprite_is_playing(sprite, animation));
+}
 
-  bool is_playing = cf_sprite_is_playing(sprite, animation_name);
-  return mrb_bool_value(is_playing);
+static mrb_value mrb_cf_sprite_width(mrb_state* mrb, mrb_value self)
+{
+  CF_Sprite* sprite;
+  mrb_get_args(mrb, "d", &sprite, &mrb_cf_sprite_type);
+  return mrb_fixnum_value(cf_sprite_width(sprite));
+}
+
+static mrb_value mrb_cf_sprite_height(mrb_state* mrb, mrb_value self)
+{
+  CF_Sprite* sprite;
+  mrb_get_args(mrb, "d", &sprite, &mrb_cf_sprite_type);
+  return mrb_fixnum_value(cf_sprite_height(sprite));
+}
+
+static mrb_value mrb_cf_sprite_initialize(mrb_state* mrb, mrb_value self)
+{
+  CF_Sprite* sprite = (CF_Sprite*) DATA_PTR(self);
+  if (sprite) mrb_free(mrb, sprite);
+  DATA_TYPE(self) = &mrb_cf_sprite_type;
+  DATA_PTR(self) = mrb_malloc(mrb, sizeof(CF_Sprite));
+  return self;
 }
 
 void mrb_cute_sprite_init(mrb_state* mrb, struct RClass* cute_module)
 {
-  struct RClass* sprite_class = mrb_define_class_under(mrb, cute_module, "Sprite", mrb->object_class);
-  MRB_SET_INSTANCE_TT(sprite_class, MRB_TT_DATA);
+  // CF_Sprite
+  struct RClass* cf_sprite_class = mrb_define_class_under(mrb, cute_module, "CF_Sprite", mrb->object_class);
+  MRB_SET_INSTANCE_TT(cf_sprite_class, MRB_TT_DATA);
 
-  mrb_define_class_method(mrb, sprite_class, "make_sprite", mrb_sprite_make_sprite, MRB_ARGS_REQ(1));
-  mrb_define_class_method(mrb, sprite_class, "make_demo_sprite", mrb_sprite_make_demo_sprite, MRB_ARGS_NONE());
-  mrb_define_method(mrb, sprite_class, "draw", mrb_sprite_draw, MRB_ARGS_NONE());
-  mrb_define_method(mrb, sprite_class, "play", mrb_sprite_play, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, sprite_class, "playing?", mrb_sprite_is_playing, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, sprite_class, "update", mrb_sprite_update, MRB_ARGS_NONE());
+  mrb_define_method(mrb, cf_sprite_class, "initialize", mrb_cf_sprite_initialize, MRB_ARGS_NONE());
+
+  // cute_sprite
+  mrb_define_module_function(mrb, cute_module, "cf_make_demo_sprite", mrb_cf_make_demo_sprite, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_defaults", mrb_cf_sprite_defaults, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_draw", mrb_cf_sprite_draw, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_height", mrb_cf_sprite_height, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_is_playing", mrb_cf_sprite_is_playing, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_play", mrb_cf_sprite_play, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_update", mrb_cf_sprite_update, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, cute_module, "cf_sprite_width", mrb_cf_sprite_width, MRB_ARGS_REQ(1));
 }

--- a/test/cute_sprite_test.rb
+++ b/test/cute_sprite_test.rb
@@ -1,0 +1,17 @@
+assert("cf_sprite_width") do
+  sprite = Cute.cf_sprite_defaults
+  assert_equal(0, Cute.cf_sprite_width(sprite))
+end
+
+assert("cf_sprite_height") do
+  sprite = Cute.cf_sprite_defaults
+  assert_equal(0, Cute.cf_sprite_height(sprite))
+end
+
+assert("Sprite") do
+  sprite = Cute::Sprite.new(nil)
+  assert_kind_of(Cute::Sprite, sprite)
+
+  assert_equal(0, sprite.width)
+  assert_equal(0, sprite.height)
+end

--- a/test/sprite_test.rb
+++ b/test/sprite_test.rb
@@ -1,38 +1,60 @@
-# assert("Cute::Sprite.make_sprite") do
-#   sprite = Cute::Sprite.make_sprite("test_sprite.ase")
-#   assert_kind_of(Cute::Sprite, sprite)
-# end
+assert("cf_sprite_defaults") do
+  sprite = Cute.cf_sprite_defaults
+  assert_kind_of(Cute::CF_Sprite, sprite)
+  assert_equal(0, Cute.cf_sprite_width(sprite))
+  assert_equal(0, Cute.cf_sprite_height(sprite))
+end
 
-assert("Cute::Sprite.make_demo_sprite") do
+assert("cf_sprite_width") do
+  sprite = Cute.cf_sprite_defaults
+  assert_equal(0, Cute.cf_sprite_width(sprite))
+end
+
+assert("cf_sprite_height") do
+  sprite = Cute.cf_sprite_defaults
+  assert_equal(0, Cute.cf_sprite_height(sprite))
+end
+
+assert("cf_make_demo_sprite") do
   Cute.make_app("Test App", 0, 10, 10, 800, 600, 0, "test_app")
-  demo_sprite = Cute::Sprite.make_demo_sprite
-  assert_kind_of(Cute::Sprite, demo_sprite)
+  sprite = Cute.cf_make_demo_sprite
+  assert_kind_of(Cute::CF_Sprite, sprite)
 end
 
-assert("Cute::Sprite#draw") do
-  sprite = Cute::Sprite.make_demo_sprite
-  assert_nothing_raised { sprite.draw }
+assert("cf_sprite_is_playing") do
+  sprite = Cute.cf_make_demo_sprite
+  assert_false(Cute.cf_sprite_is_playing(sprite, "idle"))
+  assert_false(Cute.cf_sprite_is_playing(sprite, "walk"))
 end
 
-assert("Cute::Sprite#play") do
-  sprite = Cute::Sprite.make_demo_sprite
-  assert_nothing_raised { sprite.play("idle") }
-  assert_same(sprite, sprite.play("walk"))  # Check if it returns self
+assert("cf_sprite_play") do
+  sprite = Cute.cf_make_demo_sprite
+  assert_nil(Cute.cf_sprite_play(sprite, "idle"))
+  assert_true(Cute.cf_sprite_is_playing(sprite, "idle"))
 end
 
-assert("Cute::Sprite#update") do
-  sprite = Cute::Sprite.make_demo_sprite
-  sprite.play("idle")
-  assert_nothing_raised { sprite.update }
-  assert_same(sprite, sprite.update)  # Check if it returns self
+assert("cf_sprite_update") do
+  sprite = Cute.cf_make_demo_sprite
+  assert_nil(Cute.cf_sprite_update(sprite))
 end
 
-assert("Cute::Sprite#is_playing?") do
-  sprite = Cute::Sprite.make_demo_sprite
+assert("cf_sprite_draw") do
+  sprite = Cute.cf_make_demo_sprite
+  assert_nil(Cute.cf_sprite_draw(sprite))
+end
+
+assert("Sprite") do
+  sprite = Cute::Sprite.new(nil)
+  assert_kind_of(Cute::Sprite, sprite)
+
+  assert_equal(0, sprite.width)
+  assert_equal(0, sprite.height)
+end
+
+assert("Sprite#playing?") do
+  sprite = Cute::Sprite.new(Cute.cf_make_demo_sprite)
+  assert_false(sprite.playing?("idle"))
+  assert_false(sprite.playing?("walk"))
   sprite.play("idle")
   assert_true(sprite.playing?("idle"))
-  assert_false(sprite.playing?("walk"))
-  sprite.play("walk")
-  assert_false(sprite.playing?("idle"))
-  assert_true(sprite.playing?("walk"))
 end


### PR DESCRIPTION
Only bind cf_* functions, objects will be created in Ruby land, such as the Cute::Sprite class example. This makes it easier to implement those.