### PR TITLE
This PR adds the binding for the `cf_draw_line` function from the Cut…

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -48,6 +48,21 @@ static mrb_value mrb_cf_draw_scale_v2(mrb_state* mrb, mrb_value self)
     return mrb_nil_value();
 }
 
+static mrb_value mrb_cf_draw_line(mrb_state* mrb, mrb_value self)
+{
+    mrb_value p0_obj, p1_obj;
+    mrb_float thickness;
+
+    mrb_get_args(mrb, "oof", &p0_obj, &p1_obj, &thickness);
+
+    CF_V2* p0 = mrb_cf_v2_unwrap(mrb, p0_obj);
+    CF_V2* p1 = mrb_cf_v2_unwrap(mrb, p1_obj);
+
+    cf_draw_line(*p0, *p1, (float)thickness);
+
+    return mrb_nil_value();
+}
+
 void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
 {
     mrb_define_module_function(mrb, mCute, "cf_draw_sprite", mrb_cf_draw_sprite, MRB_ARGS_REQ(1));
@@ -55,4 +70,5 @@ void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
     mrb_define_module_function(mrb, mCute, "cf_draw_scale_v2", mrb_cf_draw_scale_v2, MRB_ARGS_REQ(1));
     mrb_define_module_function(mrb, mCute, "cf_draw_push", mrb_cf_draw_push, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, mCute, "cf_draw_pop", mrb_cf_draw_pop, MRB_ARGS_NONE());
+    mrb_define_module_function(mrb, mCute, "cf_draw_line", mrb_cf_draw_line, MRB_ARGS_REQ(3));
 }

--- a/test/draw_test.rb
+++ b/test/draw_test.rb
@@ -1,0 +1,10 @@
+assert('Cute::cf_draw_line') do
+  # Create two vectors
+  v1 = Cute::V2.new(10, 10)
+  v2 = Cute::V2.new(100, 100)
+  
+  # This should not raise an error
+  assert_nothing_raised do
+    Cute::cf_draw_line(v1, v2, 2.0)
+  end
+end

--- a/test/draw_test.rb
+++ b/test/draw_test.rb
@@ -1,10 +1,20 @@
+def within_app(&block)
+  Cute.cf_make_app("Test App", 0, 10, 10, 800, 600, 0, "test_app")
+  Cute.cf_app_update
+  block.call
+  Cute.cf_app_update
+  Cute.cf_app_destroy
+end
+
 assert('Cute::cf_draw_line') do
-  # Create two vectors
-  v1 = Cute::V2.new(10, 10)
-  v2 = Cute::V2.new(100, 100)
-  
-  # This should not raise an error
-  assert_nothing_raised do
-    Cute::cf_draw_line(v1, v2, 2.0)
+  within_app do
+    # Create two vectors
+    v1 = Cute::V2.new(10, 10)
+    v2 = Cute::V2.new(100, 100)
+
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute::cf_draw_line(v1, v2, 2.0)
+    end
   end
 end


### PR DESCRIPTION
…e Framework to mruby-cute.

- Added a new binding for `cf_draw_line` in `src/draw.c`
- Added a new test file `test/draw_test.rb` to verify the function works properly

- Addresses a missing binding from issue #6
- Part of the overall missing bindings described in issue #5

This implementation follows the same pattern as other draw functions in the codebase:
1. Creates a binding that takes two `CF_V2` points and a thickness parameter
2. Provides a corresponding Ruby test file

This is the first of many draw module bindings to be implemented as outlined in issue #6.