### PR TITLE
Add draw quad

### DIFF
--- a/src/aabb.c
+++ b/src/aabb.c
@@ -1,0 +1,139 @@
+#include "aabb.h"
+#include "vector.h"
+
+extern struct RClass* cAabb;
+
+static void mrb_cf_aabb_free(mrb_state* mrb, void* p)
+{
+    CF_Aabb* data = (CF_Aabb*)p;
+    mrb_free(mrb, data);
+}
+
+const struct mrb_data_type mrb_cf_aabb_data_type = { "CF_Aabb", mrb_cf_aabb_free };
+
+static mrb_value mrb_cf_aabb_initialize(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data;
+    mrb_value min_obj, max_obj;
+
+    mrb_get_args(mrb, "oo", &min_obj, &max_obj);
+
+    CF_V2* min = mrb_cf_v2_unwrap(mrb, min_obj);
+    CF_V2* max = mrb_cf_v2_unwrap(mrb, max_obj);
+
+    data = (CF_Aabb*)mrb_malloc(mrb, sizeof(CF_Aabb));
+    *data = cf_make_aabb(*min, *max);
+
+    DATA_PTR(self) = data;
+    DATA_TYPE(self) = &mrb_cf_aabb_data_type;
+
+    return self;
+}
+
+static mrb_value mrb_cf_aabb_get_min(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = DATA_PTR(self);
+    CF_V2* min = (CF_V2*)mrb_malloc(mrb, sizeof(CF_V2));
+    *min = data->min;
+    return mrb_cf_v2_wrap(mrb, min);
+}
+
+static mrb_value mrb_cf_aabb_set_min(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = (CF_Aabb*)DATA_PTR(self);
+    mrb_value min_obj;
+    mrb_get_args(mrb, "o", &min_obj);
+    
+    CF_V2* min = mrb_cf_v2_unwrap(mrb, min_obj);
+    data->min = *min;
+    
+    return min_obj;
+}
+
+static mrb_value mrb_cf_aabb_get_max(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = (CF_Aabb*)DATA_PTR(self);
+    CF_V2* max = (CF_V2*)mrb_malloc(mrb, sizeof(CF_V2));
+    *max = data->max;
+    return mrb_cf_v2_wrap(mrb, max);
+}
+
+static mrb_value mrb_cf_aabb_set_max(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = (CF_Aabb*)DATA_PTR(self);
+    mrb_value max_obj;
+    mrb_get_args(mrb, "o", &max_obj);
+    
+    CF_V2* max = mrb_cf_v2_unwrap(mrb, max_obj);
+    data->max = *max;
+    
+    return max_obj;
+}
+
+static mrb_value mrb_cf_aabb_to_s(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = (CF_Aabb*)DATA_PTR(self);
+    char buf[128];
+
+    snprintf(buf, sizeof(buf), "Aabb(min=(%.3f, %.3f), max=(%.3f, %.3f))", 
+             data->min.x, data->min.y, data->max.x, data->max.y);
+    return mrb_str_new_cstr(mrb, buf);
+}
+
+static mrb_value mrb_cf_aabb_inspect(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data = (CF_Aabb*)DATA_PTR(self);
+    char buf[128];
+
+    snprintf(buf, sizeof(buf), "#<Cute::Aabb:0x%lx min=(%.3f, %.3f) max=(%.3f, %.3f)>", 
+             (unsigned long)data, data->min.x, data->min.y, data->max.x, data->max.y);
+    return mrb_str_new_cstr(mrb, buf);
+}
+
+static mrb_value mrb_cf_aabb_factory(mrb_state* mrb, mrb_value self)
+{
+    mrb_value min_obj, max_obj;
+    CF_Aabb* data;
+
+    mrb_get_args(mrb, "oo", &min_obj, &max_obj);
+
+    CF_V2* min = mrb_cf_v2_unwrap(mrb, min_obj);
+    CF_V2* max = mrb_cf_v2_unwrap(mrb, max_obj);
+
+    data = (CF_Aabb*)mrb_malloc(mrb, sizeof(CF_Aabb));
+    *data = cf_make_aabb(*min, *max);
+
+    return mrb_cf_aabb_wrap(mrb, data);
+}
+
+mrb_value mrb_cf_aabb_wrap(mrb_state* mrb, CF_Aabb* aabb)
+{
+    return mrb_obj_value(Data_Wrap_Struct(mrb, cAabb, &mrb_cf_aabb_data_type, aabb));
+}
+
+CF_Aabb* mrb_cf_aabb_unwrap(mrb_state* mrb, mrb_value self)
+{
+    CF_Aabb* data;
+
+    data = (CF_Aabb*)DATA_PTR(self);
+    if (data == NULL) {
+        mrb_raise(mrb, E_RUNTIME_ERROR, "uninitialized data");
+    }
+
+    return data;
+}
+
+void mrb_cute_aabb_init(mrb_state* mrb, struct RClass* mCute)
+{
+    cAabb = mrb_define_class_under(mrb, mCute, "Aabb", mrb->object_class);
+    MRB_SET_INSTANCE_TT(cAabb, MRB_TT_DATA);
+
+    mrb_define_method(mrb, cAabb, "initialize", mrb_cf_aabb_initialize, MRB_ARGS_REQ(2));
+    mrb_define_method(mrb, cAabb, "min", mrb_cf_aabb_get_min, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cAabb, "min=", mrb_cf_aabb_set_min, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, cAabb, "max", mrb_cf_aabb_get_max, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cAabb, "max=", mrb_cf_aabb_set_max, MRB_ARGS_REQ(1));
+    mrb_define_method(mrb, cAabb, "to_s", mrb_cf_aabb_to_s, MRB_ARGS_NONE());
+    mrb_define_method(mrb, cAabb, "inspect", mrb_cf_aabb_inspect, MRB_ARGS_NONE());
+    mrb_define_module_function(mrb, mCute, "Aabb", mrb_cf_aabb_factory, MRB_ARGS_REQ(2));
+}

--- a/src/aabb.h
+++ b/src/aabb.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cute.h>
+#include <mruby.h>
+#include <mruby/class.h>
+#include <mruby/data.h>
+
+struct RClass* cAabb;
+struct mrb_data_type const mrb_cf_aabb_data_type;
+
+void mrb_cute_aabb_init(mrb_state* mrb, struct RClass* mCute);
+mrb_value mrb_cf_aabb_wrap(mrb_state* mrb, CF_Aabb* aabb);
+CF_Aabb* mrb_cf_aabb_unwrap(mrb_state* mrb, mrb_value aabb);

--- a/src/cute.c
+++ b/src/cute.c
@@ -1,4 +1,5 @@
 #include "mrb_cute.h"
+#include "aabb.h"
 #include "draw.h"
 #include "sincos.h"
 #include "sprite.h"
@@ -30,6 +31,7 @@ void mrb_mruby_cute_gem_init(mrb_state* mrb)
     mrb_cute_input_init(mrb, mCute);
     mrb_cute_time_init(mrb, mCute);
     mrb_cute_stopwatch_init(mrb, mCute);
+    mrb_cute_aabb_init(mrb, mCute);
 }
 
 void mrb_mruby_cute_gem_final(mrb_state* mrb)

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,6 +1,7 @@
 #include "draw.h"
 #include "sprite.h"
 #include "vector.h"
+#include "aabb.h"
 
 static mrb_value mrb_cf_draw_sprite(mrb_state* mrb, mrb_value self)
 {
@@ -73,6 +74,37 @@ static mrb_value mrb_cf_draw_line(mrb_state* mrb, mrb_value self)
     return mrb_nil_value();
 }
 
+static mrb_value mrb_cf_draw_quad(mrb_state* mrb, mrb_value self)
+{
+    mrb_value bb_obj;
+    mrb_float thickness, chubbiness;
+
+    mrb_get_args(mrb, "off", &bb_obj, &thickness, &chubbiness);
+
+    CF_Aabb* bb = mrb_cf_aabb_unwrap(mrb, bb_obj);
+
+    cf_draw_quad(*bb, (float)thickness, (float)chubbiness);
+
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_draw_quad2(mrb_state* mrb, mrb_value self)
+{
+    mrb_value p0_obj, p1_obj, p2_obj, p3_obj;
+    mrb_float thickness, chubbiness;
+
+    mrb_get_args(mrb, "ooooff", &p0_obj, &p1_obj, &p2_obj, &p3_obj, &thickness, &chubbiness);
+
+    CF_V2* p0 = mrb_cf_v2_unwrap(mrb, p0_obj);
+    CF_V2* p1 = mrb_cf_v2_unwrap(mrb, p1_obj);
+    CF_V2* p2 = mrb_cf_v2_unwrap(mrb, p2_obj);
+    CF_V2* p3 = mrb_cf_v2_unwrap(mrb, p3_obj);
+
+    cf_draw_quad2(*p0, *p1, *p2, *p3, (float)thickness, (float)chubbiness);
+
+    return mrb_nil_value();
+}
+
 void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
 {
     mrb_define_module_function(mrb, mCute, "cf_draw_sprite", mrb_cf_draw_sprite, MRB_ARGS_REQ(1));
@@ -82,4 +114,6 @@ void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
     mrb_define_module_function(mrb, mCute, "cf_draw_push", mrb_cf_draw_push, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, mCute, "cf_draw_pop", mrb_cf_draw_pop, MRB_ARGS_NONE());
     mrb_define_module_function(mrb, mCute, "cf_draw_line", mrb_cf_draw_line, MRB_ARGS_REQ(3));
+    mrb_define_module_function(mrb, mCute, "cf_draw_quad", mrb_cf_draw_quad, MRB_ARGS_REQ(3));
+    mrb_define_module_function(mrb, mCute, "cf_draw_quad2", mrb_cf_draw_quad2, MRB_ARGS_REQ(6));
 }

--- a/test/draw_test.rb
+++ b/test/draw_test.rb
@@ -1,38 +1,52 @@
+def within_app(&block)
+  Cute.cf_make_app("Test App", 0, 10, 10, 800, 600, 0, "test_app")
+  Cute.cf_app_update
+  block.call
+  Cute.cf_app_update
+  Cute.cf_app_destroy
+end
+
 assert('Cute::cf_draw_line') do
-  # Create two vectors
-  v1 = Cute::V2.new(10, 10)
-  v2 = Cute::V2.new(100, 100)
-  
-  # This should not raise an error
-  assert_nothing_raised do
-    Cute::cf_draw_line(v1, v2, 2.0)
+  within_app do
+    # Create two vectors
+    v1 = Cute::V2.new(10, 10)
+    v2 = Cute::V2.new(100, 100)
+    
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute::cf_draw_line(v1, v2, 2.0)
+    end
   end
 end
 
 assert('Cute::cf_draw_quad') do
-  # Create min and max points for AABB
-  min = Cute::V2.new(10, 10)
-  max = Cute::V2.new(100, 100)
-  
-  # Create an AABB
-  bb = Cute::Aabb.new(min, max)
-  
-  # This should not raise an error
-  assert_nothing_raised do
-    Cute::cf_draw_quad(bb, 2.0, 0.0)
+  within_app do
+    # Create min and max points for AABB
+    min = Cute::V2.new(10, 10)
+    max = Cute::V2.new(100, 100)
+    
+    # Create an AABB
+    bb = Cute::Aabb.new(min, max)
+    
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute::cf_draw_quad(bb, 2.0, 0.0)
+    end
   end
 end
 
 assert('Cute::cf_draw_quad2') do
-  # Create four points for quad
-  p0 = Cute::V2.new(10, 10)
-  p1 = Cute::V2.new(100, 10)
-  p2 = Cute::V2.new(100, 100)
-  p3 = Cute::V2.new(10, 100)
-  
-  # This should not raise an error
-  assert_nothing_raised do
-    Cute::cf_draw_quad2(p0, p1, p2, p3, 2.0, 0.0)
+  within_app do
+    # Create four points for quad
+    p0 = Cute::V2.new(10, 10)
+    p1 = Cute::V2.new(100, 10)
+    p2 = Cute::V2.new(100, 100)
+    p3 = Cute::V2.new(10, 100)
+    
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute::cf_draw_quad2(p0, p1, p2, p3, 2.0, 0.0)
+    end
   end
 end
 

--- a/test/draw_test.rb
+++ b/test/draw_test.rb
@@ -1,21 +1,38 @@
-def within_app(&block)
-  Cute.cf_make_app("Test App", 0, 10, 10, 800, 600, 0, "test_app")
-  Cute.cf_app_update
-  block.call
-  Cute.cf_app_update
-  Cute.cf_app_destroy
+assert('Cute::cf_draw_line') do
+  # Create two vectors
+  v1 = Cute::V2.new(10, 10)
+  v2 = Cute::V2.new(100, 100)
+  
+  # This should not raise an error
+  assert_nothing_raised do
+    Cute::cf_draw_line(v1, v2, 2.0)
+  end
 end
 
-assert('Cute::cf_draw_line') do
-  within_app do
-    # Create two vectors
-    v1 = Cute::V2.new(10, 10)
-    v2 = Cute::V2.new(100, 100)
+assert('Cute::cf_draw_quad') do
+  # Create min and max points for AABB
+  min = Cute::V2.new(10, 10)
+  max = Cute::V2.new(100, 100)
+  
+  # Create an AABB
+  bb = Cute::Aabb.new(min, max)
+  
+  # This should not raise an error
+  assert_nothing_raised do
+    Cute::cf_draw_quad(bb, 2.0, 0.0)
+  end
+end
 
-    # This should not raise an error
-    assert_nothing_raised do
-      Cute::cf_draw_line(v1, v2, 2.0)
-    end
+assert('Cute::cf_draw_quad2') do
+  # Create four points for quad
+  p0 = Cute::V2.new(10, 10)
+  p1 = Cute::V2.new(100, 10)
+  p2 = Cute::V2.new(100, 100)
+  p3 = Cute::V2.new(10, 100)
+  
+  # This should not raise an error
+  assert_nothing_raised do
+    Cute::cf_draw_quad2(p0, p1, p2, p3, 2.0, 0.0)
   end
 end
 


### PR DESCRIPTION
This PR adds bindings for the `cf_draw_quad` and `cf_draw_quad2` functions from the Cute Framework. These functions allow drawing quad wireframes in two different ways:

1. `cf_draw_quad` - Drawing a quad using an AABB (Axis-Aligned Bounding Box)
2. `cf_draw_quad2` - Drawing a quad using four individual points

## Changes
- Added a new `Aabb` class to represent Axis-Aligned Bounding Boxes
- Implemented binding for `cf_draw_quad` that takes an Aabb object
- Implemented binding for `cf_draw_quad2` that takes four V2 points
- Added tests for both new functions
- Updated `mrb_cute_aabb_init` to initialize the Aabb class

## Related Issues
- Addresses tasks from issue #6 (Missing Draw Module Bindings)
- Part of the overall missing bindings described in issue #5

## Implementation
The implementation follows the same pattern as other existing draw functions in the codebase. The added bindings will allow users to draw quad wireframes in their mruby applications using the Cute Framework.