### PR TITLE
Add dedicated text module for font and text rendering functionality

### DIFF
--- a/src/cute.c
+++ b/src/cute.c
@@ -5,6 +5,7 @@
 #include "mrb_cute.h"
 #include "sincos.h"
 #include "sprite.h"
+#include "text.h"
 #include "transform.h"
 #include "vector.h"
 
@@ -36,6 +37,7 @@ void mrb_mruby_cute_gem_init(mrb_state* mrb)
     mrb_cute_aabb_init(mrb, mCute);
     mrb_cute_circle_init(mrb, mCute);
     mrb_cute_color_init(mrb, mCute);
+    mrb_cute_text_init(mrb, mCute);
 }
 
 void mrb_mruby_cute_gem_final(mrb_state* mrb)

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,7 +1,6 @@
 #include "draw.h"
 #include "aabb.h"
 #include "circle.h"
-#include "result.h"
 #include "sprite.h"
 #include "vector.h"
 
@@ -156,103 +155,6 @@ static mrb_value mrb_cf_draw_circle2(mrb_state* mrb, mrb_value self)
     return mrb_nil_value();
 }
 
-static mrb_value mrb_cf_draw_text(mrb_state* mrb, mrb_value self)
-{
-    mrb_value position_obj;
-    char* text;
-    mrb_int num_chars_to_draw = -1;
-
-    mrb_get_args(mrb, "zo|i", &text, &position_obj, &num_chars_to_draw);
-
-    CF_V2 position = *mrb_cf_v2_unwrap(mrb, position_obj);
-
-    cf_draw_text(text, position, (int)num_chars_to_draw);
-
-    return mrb_nil_value();
-}
-
-static mrb_value mrb_cf_make_font(mrb_state* mrb, mrb_value self)
-{
-    char* path;
-    char* font_name;
-
-    mrb_get_args(mrb, "zz", &path, &font_name);
-
-    CF_Result result = cf_make_font(path, font_name);
-
-    return mrb_cf_result_wrap_nested(mrb, &result);
-}
-
-static mrb_value mrb_cf_push_font(mrb_state* mrb, mrb_value self)
-{
-    char* font_name;
-
-    mrb_get_args(mrb, "z", &font_name);
-
-    cf_push_font(font_name);
-
-    return mrb_nil_value();
-}
-
-static mrb_value mrb_cf_pop_font(mrb_state* mrb, mrb_value self)
-{
-    cf_pop_font();
-    return mrb_nil_value();
-}
-
-static mrb_value mrb_cf_push_font_size(mrb_state* mrb, mrb_value self)
-{
-    mrb_float size;
-
-    mrb_get_args(mrb, "f", &size);
-
-    cf_push_font_size((float)size);
-
-    return mrb_nil_value();
-}
-
-static mrb_value mrb_cf_pop_font_size(mrb_state* mrb, mrb_value self)
-{
-    cf_pop_font_size();
-    return mrb_nil_value();
-}
-
-static mrb_value mrb_cf_text_width(mrb_state* mrb, mrb_value self)
-{
-    char* text;
-    mrb_int num_chars_to_draw = -1;
-
-    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
-
-    float width = cf_text_width(text, (int)num_chars_to_draw);
-
-    return mrb_float_value(mrb, width);
-}
-
-static mrb_value mrb_cf_text_height(mrb_state* mrb, mrb_value self)
-{
-    char* text;
-    mrb_int num_chars_to_draw = -1;
-
-    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
-
-    float height = cf_text_height(text, (int)num_chars_to_draw);
-
-    return mrb_float_value(mrb, height);
-}
-
-static mrb_value mrb_cf_text_size(mrb_state* mrb, mrb_value self)
-{
-    char* text;
-    mrb_int num_chars_to_draw = -1;
-
-    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
-
-    CF_V2 size = cf_text_size(text, (int)num_chars_to_draw);
-
-    return mrb_cf_v2_wrap_nested(mrb, &size);
-}
-
 void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
 {
     mrb_define_module_function(mrb, mCute, "cf_draw_sprite", mrb_cf_draw_sprite, MRB_ARGS_REQ(1));
@@ -268,17 +170,4 @@ void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
     mrb_define_module_function(mrb, mCute, "cf_draw_quad2", mrb_cf_draw_quad2, MRB_ARGS_REQ(6));
     mrb_define_module_function(mrb, mCute, "cf_draw_circle", mrb_cf_draw_circle, MRB_ARGS_REQ(2));
     mrb_define_module_function(mrb, mCute, "cf_draw_circle2", mrb_cf_draw_circle2, MRB_ARGS_REQ(3));
-    mrb_define_module_function(mrb, mCute, "cf_draw_text", mrb_cf_draw_text, MRB_ARGS_ARG(2, 1));
-
-    // Font functions
-    mrb_define_module_function(mrb, mCute, "cf_make_font", mrb_cf_make_font, MRB_ARGS_REQ(2));
-    mrb_define_module_function(mrb, mCute, "cf_push_font", mrb_cf_push_font, MRB_ARGS_REQ(1));
-    mrb_define_module_function(mrb, mCute, "cf_pop_font", mrb_cf_pop_font, MRB_ARGS_NONE());
-    mrb_define_module_function(mrb, mCute, "cf_push_font_size", mrb_cf_push_font_size, MRB_ARGS_REQ(1));
-    mrb_define_module_function(mrb, mCute, "cf_pop_font_size", mrb_cf_pop_font_size, MRB_ARGS_NONE());
-
-    // Text measurement functions
-    mrb_define_module_function(mrb, mCute, "cf_text_width", mrb_cf_text_width, MRB_ARGS_ARG(1, 1));
-    mrb_define_module_function(mrb, mCute, "cf_text_height", mrb_cf_text_height, MRB_ARGS_ARG(1, 1));
-    mrb_define_module_function(mrb, mCute, "cf_text_size", mrb_cf_text_size, MRB_ARGS_ARG(1, 1));
 }

--- a/src/mrb_cute.h
+++ b/src/mrb_cute.h
@@ -19,6 +19,7 @@ void mrb_cute_time_init(mrb_state* mrb, struct RClass* mCute);
 void mrb_cute_stopwatch_init(mrb_state* mrb, struct RClass* mCute);
 void mrb_cute_circle_init(mrb_state* mrb, struct RClass* mCute);
 void mrb_cute_color_init(mrb_state* mrb, struct RClass* mCute);
+void mrb_cute_text_init(mrb_state* mrb, struct RClass* mCute);
 
 mrb_value mrb_cf_result_from_cf_result(mrb_state* mrb, CF_Result result);
 

--- a/src/result.c
+++ b/src/result.c
@@ -58,6 +58,13 @@ static mrb_value mrb_cf_result_success(mrb_state* mrb, mrb_value self)
     return mrb_cf_result_wrap(mrb, result_ptr);
 }
 
+mrb_value mrb_cf_result_from_cf_result(mrb_state* mrb, CF_Result result)
+{
+    CF_Result* result_ptr = (CF_Result*)mrb_malloc(mrb, sizeof(CF_Result));
+    *result_ptr = result;
+    return mrb_cf_result_wrap(mrb, result_ptr);
+}
+
 void mrb_cute_result_init(mrb_state* mrb, struct RClass* mCute)
 {
     // CF_Result

--- a/src/text.c
+++ b/src/text.c
@@ -1,0 +1,116 @@
+#include "text.h"
+#include "vector.h"
+#include "result.h"
+
+static mrb_value mrb_cf_make_font(mrb_state* mrb, mrb_value self)
+{
+    char* path;
+    char* font_name;
+
+    mrb_get_args(mrb, "zz", &path, &font_name);
+
+    CF_Result result = cf_make_font(path, font_name);
+
+    return mrb_cf_result_from_cf_result(mrb, result);
+}
+
+static mrb_value mrb_cf_push_font(mrb_state* mrb, mrb_value self)
+{
+    char* font_name;
+
+    mrb_get_args(mrb, "z", &font_name);
+
+    cf_push_font(font_name);
+
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_pop_font(mrb_state* mrb, mrb_value self)
+{
+    cf_pop_font();
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_push_font_size(mrb_state* mrb, mrb_value self)
+{
+    mrb_float size;
+
+    mrb_get_args(mrb, "f", &size);
+
+    cf_push_font_size((float)size);
+
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_pop_font_size(mrb_state* mrb, mrb_value self)
+{
+    cf_pop_font_size();
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_draw_text(mrb_state* mrb, mrb_value self)
+{
+    mrb_value position_obj;
+    char* text;
+    mrb_int num_chars_to_draw = -1;
+
+    mrb_get_args(mrb, "zo|i", &text, &position_obj, &num_chars_to_draw);
+
+    CF_V2* position = mrb_cf_v2_unwrap(mrb, position_obj);
+
+    cf_draw_text(text, *position, (int)num_chars_to_draw);
+
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_text_width(mrb_state* mrb, mrb_value self)
+{
+    char* text;
+    mrb_int num_chars_to_draw = -1;
+
+    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
+
+    float width = cf_text_width(text, (int)num_chars_to_draw);
+
+    return mrb_float_value(mrb, width);
+}
+
+static mrb_value mrb_cf_text_height(mrb_state* mrb, mrb_value self)
+{
+    char* text;
+    mrb_int num_chars_to_draw = -1;
+
+    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
+
+    float height = cf_text_height(text, (int)num_chars_to_draw);
+
+    return mrb_float_value(mrb, height);
+}
+
+static mrb_value mrb_cf_text_size(mrb_state* mrb, mrb_value self)
+{
+    char* text;
+    mrb_int num_chars_to_draw = -1;
+
+    mrb_get_args(mrb, "z|i", &text, &num_chars_to_draw);
+
+    CF_V2 size = cf_text_size(text, (int)num_chars_to_draw);
+
+    return mrb_cf_v2_wrap_nested(mrb, &size);
+}
+
+void mrb_cute_text_init(mrb_state* mrb, struct RClass* mCute)
+{
+    // Font functions
+    mrb_define_module_function(mrb, mCute, "cf_make_font", mrb_cf_make_font, MRB_ARGS_REQ(2));
+    mrb_define_module_function(mrb, mCute, "cf_push_font", mrb_cf_push_font, MRB_ARGS_REQ(1));
+    mrb_define_module_function(mrb, mCute, "cf_pop_font", mrb_cf_pop_font, MRB_ARGS_NONE());
+    mrb_define_module_function(mrb, mCute, "cf_push_font_size", mrb_cf_push_font_size, MRB_ARGS_REQ(1));
+    mrb_define_module_function(mrb, mCute, "cf_pop_font_size", mrb_cf_pop_font_size, MRB_ARGS_NONE());
+
+    // Text functions
+    mrb_define_module_function(mrb, mCute, "cf_draw_text", mrb_cf_draw_text, MRB_ARGS_ARG(2, 1));
+    mrb_define_module_function(mrb, mCute, "cf_text_width", mrb_cf_text_width, MRB_ARGS_ARG(1, 1));
+    mrb_define_module_function(mrb, mCute, "cf_text_height", mrb_cf_text_height, MRB_ARGS_ARG(1, 1));
+    mrb_define_module_function(mrb, mCute, "cf_text_size", mrb_cf_text_size, MRB_ARGS_ARG(1, 1));
+}

--- a/src/text.h
+++ b/src/text.h
@@ -1,0 +1,8 @@
+#ifndef MRB_CUTE_TEXT_H
+#define MRB_CUTE_TEXT_H
+
+#include "mrb_cute.h"
+
+void mrb_cute_text_init(mrb_state* mrb, struct RClass* mCute);
+
+#endif // MRB_CUTE_TEXT_H

--- a/test/text_test.rb
+++ b/test/text_test.rb
@@ -1,0 +1,33 @@
+assert 'Cute::cf_make_font' do
+  result = Cute::cf_make_font('non_existent_file.ttf', 'test_font')
+  assert_true Cute::cf_is_error(result)
+end
+
+assert 'Cute::cf_push_font and Cute::cf_pop_font' do
+  # Just test that the methods exist and can be called without errors
+  Cute::cf_push_font('default')
+  Cute::cf_pop_font
+  assert_true true
+end
+
+assert 'Cute::cf_push_font_size and Cute::cf_pop_font_size' do
+  # Just test that the methods exist and can be called without errors
+  Cute::cf_push_font_size(12.0)
+  Cute::cf_pop_font_size
+  assert_true true
+end
+
+assert 'Cute::cf_text_width' do
+  width = Cute::cf_text_width('test')
+  assert_kind_of Float, width
+end
+
+assert 'Cute::cf_text_height' do
+  height = Cute::cf_text_height('test')
+  assert_kind_of Float, height
+end
+
+assert 'Cute::cf_text_size' do
+  size = Cute::cf_text_size('test')
+  assert_equal 'Cute::V2', size.class.to_s
+end


### PR DESCRIPTION
- Moved text and font functions from draw.c to new text.c file
- Added text_test.rb for text functionality testing
- Implemented missing mrb_cf_result_from_cf_result function
- Updated header files and initialization functions

This refactoring makes the codebase more modular and matches the project's organization pattern with dedicated files for different functionality components.