### PR TITLE
Add bindings for cf_draw_circle_fill and cf_draw_circle_fill2 functions

### DIFF
--- a/docstub/circle.rb
+++ b/docstub/circle.rb
@@ -73,4 +73,19 @@ module Cute
   # @return [nil]
   def self.cf_draw_circle2(position, radius, thickness)
   end
+
+  # @method cf_draw_circle_fill
+  # @brief Draws a filled circle
+  # @param [Circle] circle The circle to draw as filled
+  # @return [nil]
+  def self.cf_draw_circle_fill(circle)
+  end
+
+  # @method cf_draw_circle_fill2
+  # @brief Draws a filled circle with the specified position and radius
+  # @param [V2] position The position vector for the center of the circle
+  # @param [Float] radius The radius of the circle
+  # @return [nil]
+  def self.cf_draw_circle_fill2(position, radius)
+  end
 end

--- a/src/draw.c
+++ b/src/draw.c
@@ -156,6 +156,33 @@ static mrb_value mrb_cf_draw_circle2(mrb_state* mrb, mrb_value self)
     return mrb_nil_value();
 }
 
+static mrb_value mrb_cf_draw_circle_fill(mrb_state* mrb, mrb_value self)
+{
+    mrb_value circle_obj;
+
+    mrb_get_args(mrb, "o", &circle_obj);
+
+    CF_Circle* circle = mrb_cf_circle_unwrap(mrb, circle_obj);
+
+    cf_draw_circle_fill(*circle);
+
+    return mrb_nil_value();
+}
+
+static mrb_value mrb_cf_draw_circle_fill2(mrb_state* mrb, mrb_value self)
+{
+    mrb_value position_obj;
+    mrb_float radius;
+
+    mrb_get_args(mrb, "of", &position_obj, &radius);
+
+    CF_V2* position = mrb_cf_v2_unwrap(mrb, position_obj);
+
+    cf_draw_circle_fill2(*position, (float)radius);
+
+    return mrb_nil_value();
+}
+
 static mrb_value mrb_cf_draw_text(mrb_state* mrb, mrb_value self)
 {
     mrb_value position_obj;
@@ -268,6 +295,8 @@ void mrb_cute_draw_init(mrb_state* mrb, struct RClass* mCute)
     mrb_define_module_function(mrb, mCute, "cf_draw_quad2", mrb_cf_draw_quad2, MRB_ARGS_REQ(6));
     mrb_define_module_function(mrb, mCute, "cf_draw_circle", mrb_cf_draw_circle, MRB_ARGS_REQ(2));
     mrb_define_module_function(mrb, mCute, "cf_draw_circle2", mrb_cf_draw_circle2, MRB_ARGS_REQ(3));
+    mrb_define_module_function(mrb, mCute, "cf_draw_circle_fill", mrb_cf_draw_circle_fill, MRB_ARGS_REQ(1));
+    mrb_define_module_function(mrb, mCute, "cf_draw_circle_fill2", mrb_cf_draw_circle_fill2, MRB_ARGS_REQ(2));
     mrb_define_module_function(mrb, mCute, "cf_draw_text", mrb_cf_draw_text, MRB_ARGS_ARG(2, 1));
 
     // Font functions

--- a/test/draw_test.rb
+++ b/test/draw_test.rb
@@ -92,6 +92,29 @@ within_app do
     end
   end
 
+  assert("Cute::cf_draw_circle_fill") do
+    # Create a position for the circle
+    position = Cute::V2.new(100.0, 100.0)
+
+    # Create a circle with radius 50
+    circle = Cute::Circle.new(position, 50.0)
+
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute.cf_draw_circle_fill(circle)
+    end
+  end
+
+  assert("Cute::cf_draw_circle_fill2") do
+    # Create a position for the circle
+    position = Cute::V2.new(100.0, 100.0)
+
+    # This should not raise an error
+    assert_nothing_raised do
+      Cute.cf_draw_circle_fill2(position, 50.0)
+    end
+  end
+
   assert("Cute::cf_make_font") do
     # Just test that the function exists and doesn't crash
     assert_nothing_raised do


### PR DESCRIPTION
## Summary
- Added bindings for the Cute Framework's `cf_draw_circle_fill` and `cf_draw_circle_fill2` functions
- Created tests to ensure proper functionality
- Updated documentation in docstub to include the new functions

## Test plan
- Run `rake test` to verify that all tests pass
- Run `rake example` to ensure the example code still works
- Try drawing filled circles using both the Circle object method and the position/radius method

🤖 Generated with [Claude Code](https://claude.ai/code)